### PR TITLE
Open Github links in a new tab

### DIFF
--- a/project/app/frontend/components/package-readme.jsx
+++ b/project/app/frontend/components/package-readme.jsx
@@ -29,7 +29,7 @@ const PackageReadme = React.createClass({
             </span>
           </div>
 
-          <a className={styles.externalLink} href={this.externalLink()}>
+          <a className={styles.externalLink} href={this.externalLink()} target='_blank'>
             View on GitHub <Icon type='github' />
           </a>
         </div>


### PR DESCRIPTION
Adding `target='_blank'` to Github links
